### PR TITLE
Assign arguments

### DIFF
--- a/DPLocalization/NSObject+DPLocalization.m
+++ b/DPLocalization/NSObject+DPLocalization.m
@@ -64,6 +64,7 @@ static NSString * const kAutolocOnDeallocBlockKey = @"autolocOnDeallocBlockKey";
 
         self.autolocKey = key;
         self.autolocKeyPath = keyPath;
+        self.autolocArgs = arguments;
         [self localize];
     }
 }


### PR DESCRIPTION
So formatted localization strings work properly
